### PR TITLE
The column line is enough.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,5 @@
     // Columns at which to show vertical rulers
     "editor.rulers": [100],
 
-    // Controls after how many characters the editor will wrap to the next line. Setting this to 0 turns on viewport width wrapping (word wrapping). Setting this to -1 forces the editor to never wrap.
-    "editor.wordWrap": "wordWrapColumn",
-    "editor.wordWrapColumn": 100,
-
     "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
Please, don't mess with my word wrap settings. I believe this is
one of those settings that those who care about it *really* care
about it. If `tslint` wants to complain about too-long lines,
let me address them, myself, please.