### PR TITLE
add standard npm script definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
   },
   "scripts": {
     "skyux": "skyux",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "skyux test",
+    "test:watch": "skyux watch",
+    "start": "skyux serve",
+    "e2e": "skyux e2e",
+    "lint": "skyux lint"
   },
   "keywords": [],
   "author": "Blackbaud",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "skyux": "skyux",
+    "build": "skyux build",
     "test": "skyux test",
     "test:watch": "skyux watch",
     "start": "skyux serve",


### PR DESCRIPTION
also includes some non-standard definitions that are sky-specific

my justification for this is purely selfish. my npm muscle memory insists on running `npm start`. 