### PR TITLE
Add config to connect to edge and chrome debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,44 @@
 {
-    // Use IntelliSense to learn about possible Node.js debug attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Debug SKY UX",
-            "type": "node2",
-            "request": "launch",
-            "program": "${workspaceRoot}/../skyux-cli/bin/skyux.js",
-            "stopOnEntry": false,
-            "args": ["build"],
-            "cwd": "${workspaceRoot}",
-            "preLaunchTask": null,
-            "runtimeExecutable": null,
-            "runtimeArgs": [
-                "--nolazy"
-            ],
-            "env": {
-                "NODE_ENV": "development"
-            },
-            "console": "integratedTerminal",
-            "sourceMaps": false,
-            "outFiles": []
-        }
-    ]
+  // Use IntelliSense to learn about possible Node.js debug attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug SKY UX",
+      "type": "node2",
+      "request": "launch",
+      "program": "${workspaceRoot}/../skyux-cli/bin/skyux.js",
+      "stopOnEntry": false,
+      "args": [
+        "build"
+      ],
+      "cwd": "${workspaceRoot}",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "runtimeArgs": [
+        "--nolazy"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "integratedTerminal",
+      "sourceMaps": false,
+      "outFiles": []
+    },
+    {
+      "type": "edge",
+      "request": "attach",
+      "name": "Attach to Microsoft Edge",
+      "port": 2015,
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Attach to Chrome",
+      "port": 2016,
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
 }


### PR DESCRIPTION
Add config to connect VS Code debugger to running SPA when running in a browser that uses the Chrome DevTools Protocol.

https://github.com/Microsoft/vscode-chrome-debug
https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge

![image](https://user-images.githubusercontent.com/5880556/63041265-7262e880-be95-11e9-8d0f-b3ba20c50443.png)
